### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/chessground/configure.ts
+++ b/src/chessground/configure.ts
@@ -89,8 +89,10 @@ function setRookCastle(state: State): void {
 
 function merge(base: any, extend: any) {
   for (const key in extend) {
-    if (isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key])
-    else base[key] = extend[key]
+    if (!Object.prototype.hasOwnProperty.call(extend, key)) continue;
+    if (key === "__proto__" || key === "constructor") continue;
+    if (isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
+    else base[key] = extend[key];
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/lichobile/security/code-scanning/2](https://github.com/codeallthethingsbreak/lichobile/security/code-scanning/2)

To fix the issue, the `merge` function should be updated to prevent prototype pollution. This can be achieved by blocking dangerous property names (`__proto__` and `constructor`) and ensuring that only own properties of the `extend` object are merged. This approach ensures that malicious properties cannot be injected into `Object.prototype`.

**Steps to fix:**
1. Add a check to skip merging properties named `__proto__` or `constructor`.
2. Use `Object.prototype.hasOwnProperty.call(extend, key)` to ensure only own properties of `extend` are considered for merging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
